### PR TITLE
Fixed error in realloc in objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ install:
 
 script:
   - cd build
-  - ctest
+  - ctest -VV

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,13 @@ branches:
     - master
 
 addons:
-  apt:
-    sources:
-      - george-edison55-precise-backports
     packages:
       - cmake
       - cmake-data
 
 before_install:
   - sudo apt-get install cmake
-  - git clone https://github.com/antirez/redis.git
+  - git clone --depth 1 https://github.com/antirez/redis.git
   - cd redis
   - make
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ before_install:
   - cd redis
   - make
   - cd ..
-  - sudo apt-get install python python-pip
-  - sudo -H pip install redis
+  - pip install redis
 
 install:
   - ./bootstrap.sh

--- a/src/object.c
+++ b/src/object.c
@@ -337,7 +337,7 @@ Node *__obj_find(t_dict *o, const char *key, int *idx) {
 
 #define __obj_insert(o, n)                                             \
     if (o->len >= o->cap) {                                            \
-        o->cap = o->cap ? MIN(o->cap * 2, 1024 * 1024) : 1;            \
+        o->cap += o->cap ? MIN(o->cap, 1024 * 1024) : 1;               \
         o->entries = realloc(o->entries, o->cap * sizeof(t_keyval *)); \
     }                                                                  \
     o->entries[o->len++] = n;


### PR DESCRIPTION
This bug does not allow (and will cause crash on) objects larger than 1M elements.