### PR TITLE
Prevent float point serialization losing precision, fixes #6

### DIFF
--- a/src/json_object.c
+++ b/src/json_object.c
@@ -339,7 +339,7 @@ inline static void _JSONSerialize_BeginValue(Node *n, void *ctx) {
                 else if (fabs(n->value.numval) < 1.0e-6 || fabs(n->value.numval) > 1.0e9)
                     b->buf = sdscatprintf(b->buf, "%e", n->value.numval);
                 else
-                    b->buf = sdscatprintf(b->buf, "%g", n->value.numval);
+                    b->buf = sdscatprintf(b->buf, "%lf", n->value.numval);
                 break;
             case N_STRING:
                 _JSONSerialize_StringValue(n, b);

--- a/src/json_object.c
+++ b/src/json_object.c
@@ -339,7 +339,7 @@ inline static void _JSONSerialize_BeginValue(Node *n, void *ctx) {
                 else if (fabs(n->value.numval) < 1.0e-6 || fabs(n->value.numval) > 1.0e9)
                     b->buf = sdscatprintf(b->buf, "%e", n->value.numval);
                 else
-                    b->buf = sdscatprintf(b->buf, "%lf", n->value.numval);
+                    b->buf = sdscatprintf(b->buf, "%.17g", n->value.numval);
                 break;
             case N_STRING:
                 _JSONSerialize_StringValue(n, b);

--- a/test/pytest/test.py
+++ b/test/pytest/test.py
@@ -106,11 +106,18 @@ class ReJSONTestCase(ModuleTestCase(module_path=module_path, redis_path=redis_pa
     def testSetRootWithJSONValuesShouldSucceed(self):
         """Test that the root of a JSON key can be set with any valid JSON"""
         with self.redis() as r:
-            for v in ['"string"', '1', '-2', '3.14', 'null', 'true', 'false', '[]', '{}']:
+            for v in ['string', 1, -2, 3.14, None, True, False, [], {}]:
                 r.delete('test')
-                self.assertOk(r.execute_command('JSON.SET', 'test', '.', v), v)
+                j = json.dumps(v)
+                self.assertOk(r.execute_command('JSON.SET', 'test', '.', j), v)
                 self.assertExists(r, 'test')
-                self.assertEqual(r.execute_command('JSON.GET', 'test'), v, v)
+                s = json.loads(r.execute_command('JSON.GET', 'test'))
+                if type(v) is dict:
+                    self.assertDictEqual(v, s, v)
+                elif type(v) is list:
+                    self.assertListEqual(v, s, v)
+                else:
+                    self.assertEqual(v, s, v)
 
     def testSetReplaceRootShouldSucceed(self):
         """Test replacing the root of an existing key with a valid object succeeds"""


### PR DESCRIPTION
Fixes the issue in serialization that falsely uses the `%g` flag and causes double precision float points to lose precision.