### PR TITLE
Adds verbosity to search path errors

### DIFF
--- a/src/json_path.h
+++ b/src/json_path.h
@@ -30,6 +30,13 @@
 #define PARSE_OK 0
 #define PARSE_ERR 1
 
+#define JSON_PATH_IDENT_FIRST_CHAR_ERR "an identifier can only begin with a letter, a dollar sign or an underscore - use bracket notation for anything else"
+#define JSON_PATH_IDENT_ERR "an identifier can only contain letters, digits, dollar signs or underscores - use bracket notation for anything else"
+#define JSON_PATH_BRACKET_FIRST_CHAR_ERR "square brackets can only contain integers, single- or double-quoted strings"
+#define JSON_PATH_NUMBER_ERR "expecting a digit - that's what integers are made of - or a closing bracket"
+#define JSON_PATH_NEGATIVE_NUMBER_ERR "expecting a digit - a negative integer must have at least one"
+#define JSON_PATH_MISSING_BRACKET_ERR "expecting a right square bracket after a string identifier"
+
 // token type identifier
 typedef enum {
     T_KEY,
@@ -38,24 +45,32 @@ typedef enum {
 
 // tokenizer state
 typedef enum {
-    S_NULL,         // start state
-    S_IDENT,        // an identifier
-    S_NUMBER,       // an index number
-    S_DKEY,         // a key in double quotes
-    S_SKEY,         // a key in single quotes
-    S_BRACKET,      // subscript (could be a key or an index)
-    S_DOT,          // child separator
-    S_MINUS,        // a negative index
+    S_NULL,    // start state
+    S_ROOT,    // the root
+    S_IDENT,   // an identifier
+    S_NUMBER,  // an index number
+    S_DKEY,    // a key in double quotes
+    S_SKEY,    // a key in single quotes
+    S_BRACKET, // subscript (could be a key or an index)
+    S_DOT,     // child separator
+    S_MINUS,   // a negative index
 } tokenizerState;
 
 // the token we're now on
-typedef struct {
+typedef struct
+{
     tokenType type;
     char *s;
     size_t len;
 } token;
 
-int _tokenizePath(const char *json, size_t len, SearchPath *path);
+typedef struct
+{
+    char *errmsg;
+    size_t offset;
+} JSONSearchPathError_t;
+
+int _tokenizePath(const char *json, size_t len, SearchPath *path, JSONSearchPathError_t *err);
 
 /**
 * Parse a JSON path expression into the initialized search path object.
@@ -64,8 +79,10 @@ int _tokenizePath(const char *json, size_t len, SearchPath *path);
 *   foo["bar"]["baz"][3]
 *   foo[3]
 *
-*   Note: string keys right now need to be ascii, we do not support unicode keys
+* `json` is the path and `len` is its length. `path` is a pointer to the resulting search path, and
+* `err` is an optional error container.
+* Note: string keys right now need to be ascii, we do not support unicode keys
 */
-int ParseJSONPath(const char *json, size_t len, SearchPath *path);
+int ParseJSONPath(const char *json, size_t len, SearchPath *path, JSONSearchPathError_t *err);
 
 #endif

--- a/src/rejson.h
+++ b/src/rejson.h
@@ -34,7 +34,6 @@
 
 #define RM_ERRORMSG_SYNTAX "ERR syntax error"
 
-#define REJSON_ERROR_PARSE_PATH "ERR error parsing path"
 #define REJSON_ERROR_EMPTY_STRING "ERR the empty string is not a valid JSON value"
 #define REJSON_ERROR_JSONOBJECT_ERROR "ERR unspecified json_object error (probably OOM)"
 #define REJSON_ERROR_SERIALIZE "ERR object serialization to JSON failed"

--- a/test/test_object.c
+++ b/test/test_object.c
@@ -348,7 +348,7 @@ MU_TEST(testPathParse) {
     const char *path = "foo.bar[3][\"baz\"].bar[\"boo\"][''][6379][-17].$nake_ca$e____";
 
     SearchPath sp = NewSearchPath(0);
-    int rc = ParseJSONPath(path, strlen(path), &sp);
+    int rc = ParseJSONPath(path, strlen(path), &sp, NULL);
     mu_assert_int_eq(rc, PARSE_OK);
 
     mu_assert_int_eq(sp.len, 10);
@@ -369,7 +369,7 @@ MU_TEST(testPathParse) {
         "1foo",     "f?oo",        "foo\n",    "foo\tbar",      "foobar[-i]",   NULL};
 
     for (int idx = 0; badpaths[idx] != NULL; idx++) {
-        mu_check(ParseJSONPath(badpaths[idx], strlen(badpaths[idx]), &sp) == PARSE_ERR);
+        mu_check(ParseJSONPath(badpaths[idx], strlen(badpaths[idx]), &sp, NULL) == PARSE_ERR);
     }
 
     SearchPath_Free(&sp);
@@ -379,7 +379,7 @@ MU_TEST(testPathParseRoot) {
     const char *path = ".";
 
     SearchPath sp = NewSearchPath(0);
-    int rc = ParseJSONPath(path, strlen(path), &sp);
+    int rc = ParseJSONPath(path, strlen(path), &sp, NULL);
     mu_assert_int_eq(rc, PARSE_OK);
     mu_assert_int_eq(sp.len, 1);
     mu_check(NT_ROOT == sp.nodes[0].type);


### PR DESCRIPTION
Search path errors now report the type of error and the offset in
the path. This also fixes a subtle issue of keys starting with a
digit immediately after the root (i.e. '.1foo') not producing an
error.

Fixes #11