### PR TITLE
Fixes serialization to AOF

### DIFF
--- a/src/json_type.c
+++ b/src/json_type.c
@@ -45,9 +45,8 @@ void JSONTypeAofRewrite(RedisModuleIO *aof, RedisModuleString *key, void *value)
 
     // serialize it
     JSONSerializeOpt jsopt = {.indentstr = "", .newlinestr = "", .spacestr = ""};
-    sds json = sdsnewlen("\"", 1);
+    sds json = sdsempty();
     SerializeNodeToJSON(jt->root, &jsopt, &json);
-    json = sdscatlen(json, "\"", 1);
     RedisModule_EmitAOF(aof, "JSON.SET", "scb", key, OBJECT_ROOT_PATH, json, sdslen(json));
     sdsfree(json);
 }


### PR DESCRIPTION
Removes enclosing redundant double quotes.

This resolves #14, but still leaves two uncovered topics:

1. AOF tests are missing
2. Need to capture and report the currently-silent AOF loading errors