### PR TITLE
add simple unicode support to show unicode string proprely when use JOSN.GET

### DIFF
--- a/src/json_object.c
+++ b/src/json_object.c
@@ -345,7 +345,7 @@ inline static void _JSONSerialize_StringValue(Node *n, void *ctx) {
                 if ((unsigned char)*p > 31 && isprint(*p))
                     b->buf = sdscatprintf(b->buf, "%c", *p);
                 // for unicode
-                else if (_get_unicode(p, &step, len) == 0)
+                else if (_get_unicode(p, &step, len))
                   b->buf = sdscatlen(b->buf, p, step);
                 else
                     b->buf = sdscatprintf(b->buf, "\\u%04x", (unsigned char)*p);

--- a/test/test_json_object.c
+++ b/test/test_json_object.c
@@ -398,6 +398,25 @@ MU_TEST(test_oj_special_characters) {
     Node_Free(n);
 }
 
+MU_TEST(test_oj_unicode_characters) {
+    Node *n;
+    sds str = sdsempty();
+    JSONSerializeOpt opt = {"", "", ""};
+    // unicode string do not need to convert to hex
+    char *json = "\"\xe6\x88\x91\xe8\x83\xbd\xe5\x90\x9e\xe4\xb8\x8b\xe7\x8e\xbb\xe7\x92\x83\xe8\x80\x8c\xe4\xb8\x8d\xe4\xbc\xa4\xe8\xba\xab\xe4\xbd\x93\"\x00";
+    char *unicodes = "\xe6\x88\x91\xe8\x83\xbd\xe5\x90\x9e\xe4\xb8\x8b\xe7\x8e\xbb\xe7\x92\x83\xe8\x80\x8c\xe4\xb8\x8d\xe4\xbc\xa4\xe8\xba\xab\xe4\xbd\x93\x00";
+
+    n = NewStringNode(unicodes, strlen(unicodes));
+    mu_check(n);
+    SerializeNodeToJSON(n, &opt, &str);
+    mu_check(str);
+    printf("\n%s\n", json);
+    printf("\n%s\n", str);
+    mu_check(0 == strncmp(json, str, strlen(str)));
+    sdsfree(str);
+    Node_Free(n);
+}
+
 MU_TEST_SUITE(test_json_literals) {
     MU_RUN_TEST(test_jo_create_literal_null);
     MU_RUN_TEST(test_jo_create_literal_true);
@@ -420,6 +439,7 @@ MU_TEST_SUITE(test_object_to_json) {
     MU_RUN_TEST(test_oj_dict);
     MU_RUN_TEST(test_oj_array);
     MU_RUN_TEST(test_oj_special_characters);
+    MU_RUN_TEST(test_oj_unicode_characters);
 }
 
 int main(int argc, char *argv[]) {

--- a/test/test_json_object.c
+++ b/test/test_json_object.c
@@ -410,8 +410,6 @@ MU_TEST(test_oj_unicode_characters) {
     mu_check(n);
     SerializeNodeToJSON(n, &opt, &str);
     mu_check(str);
-    printf("\n%s\n", json);
-    printf("\n%s\n", str);
     mu_check(0 == strncmp(json, str, strlen(str)));
     sdsfree(str);
     Node_Free(n);

--- a/test/test_json_object.c
+++ b/test/test_json_object.c
@@ -393,7 +393,6 @@ MU_TEST(test_oj_special_characters) {
     mu_check(n);
     SerializeNodeToJSON(n, &opt, &str);
     mu_check(str);
-    printf("%s", json);
     mu_check(0 == strncmp(json, str, strlen(str)));
     sdsfree(str);
     Node_Free(n);

--- a/test/test_json_object.c
+++ b/test/test_json_object.c
@@ -393,6 +393,7 @@ MU_TEST(test_oj_special_characters) {
     mu_check(n);
     SerializeNodeToJSON(n, &opt, &str);
     mu_check(str);
+    printf("%s", json);
     mu_check(0 == strncmp(json, str, strlen(str)));
     sdsfree(str);
     Node_Free(n);


### PR DESCRIPTION
#35
Show unicode  properly instead of hex. For example:
```
127.0.0.1:6379>  JSON.SET a . '{"test":"测试"}'
OK
127.0.0.1:6379> JSON.GET a
{"test":"测试"}
```
instead of
```
127.0.0.1:6379> JSON.SET test . '{"test":"测试"}'
OK
127.0.0.1:6379> JSON.GET test .
{test:"\u00e6\u00b5\u008b\u00e8\u00af\u0095"}
```
And I also add a simple unicode test case...