### PR TITLE
Add `NOESCAPE` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - cd redis
   - make
   - cd ..
-  - pip install redis rmtest ramp-packer
+  - pip install --user redis rmtest ramp-packer
 
 script:
   - make test

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -60,6 +60,7 @@ JSON.GET <key>
          [INDENT indentation-string]
          [NEWLINE line-break-string]
          [SPACE space-string]
+         [NOESCAPE]
          [path ...]
 ```
 
@@ -73,6 +74,11 @@ The following subcommands change the reply's format and are all set to the empty
 *   `INDENT` sets the indentation string for nested levels
 *   `NEWLINE` sets the string that's printed at the end of each line
 *   `SPACE` sets the string that's put between a key and a value
+
+The `NOESCAPE` option will disable the sending of \uXXXX escapes for non-ascii
+characters. This option should be used for efficiency if you deal mainly with
+such text. The escaping of JSON strings will be deprecated in the future and this
+option will become the implicit default.
 
 Pretty-formatted JSON is producible with `redis-cli` by following this example:
 

--- a/src/json_object.h
+++ b/src/json_object.h
@@ -66,6 +66,7 @@ typedef struct {
     char *indentstr;   // indentation string
     char *newlinestr;  // linebreak string
     char *spacestr;    // spacing before/after element in size=1 containers, and after keys
+    int noescape;      // Don't return escape in output
 } JSONSerializeOpt;
 
 /**

--- a/src/rejson.c
+++ b/src/rejson.c
@@ -708,6 +708,7 @@ error:
  *   - `INDENT` sets the indentation string for nested levels
  *   - `NEWLINE` sets the string that's printed at the end of each line
  *   - `SPACE` sets the string that's put between a key and a value
+ *   - `NOESCAPE` Don't escape any JSON characters.
  *
  * Reply: Bulk String, specifically the JSON serialization.
  * The reply's structure depends on the on the number of paths. A single path results in the value
@@ -758,6 +759,10 @@ int JSONGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
         } else {
             jsopt.spacestr = "";
         }
+    }
+    if (RMUtil_ArgExists("noescape", argv,argc, 2)) {
+        jsopt.noescape = 1;
+        pathpos++;
     }
 
     // initialize the reply

--- a/test/pytest/test.py
+++ b/test/pytest/test.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from rmtest import ModuleTestCase
 import redis
 import unittest
@@ -672,6 +674,13 @@ class ReJSONTestCase(ModuleTestCase('../../src/rejson.so')):
             # This shouldn't crash Redis
             r.execute_command('JSON.GET', 'test', 'foo', 'foo')
 
+    def testNoescape(self):
+        # Store a path and see if it acts appropriately with NOESCAPE
+        self.cmd('JSON.SET', 'escapeTest', '.', '{"key":"שלום"}')
+        rv = self.cmd('JSON.GET', 'escapeTest', '.')
+        self.assertEqual('{"key":"\u00d7\u00a9\u00d7\u009c\u00d7\u0095\u00d7\u009d"}', rv)
+        rv = self.cmd('JSON.GET', 'escapeTest', 'NOESCAPE', '.')
+        self.assertEqual('{"key":"שלום"}', rv)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This allows the return of "raw" JSON string data. In reality this should
be the default (and we should never need to escape anything that doesn't
need escaping per the standard), but we don't want to break apps who are
using it to transport "binary" data.