### PR TITLE
Fix version number of RAMP packaging script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - cd redis
   - make
   - cd ..
-  - pip install redis rmtest ramp-packer
+  - pip install --user redis rmtest ramp-packer==1.2.3
 
 script:
   - make test


### PR DESCRIPTION
To protect from breaking changes, until we complete the RP release, let's fix RAMP on version 1.2.3 in travis.